### PR TITLE
eH: Enable proper connections to databases without pw requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ usage: mysql2csv [-h] [--loglevel LOG_LEVEL] [--host DB_HOST] [--user DB_USER]
                  [--password DB_PASSWORD] [--database DB_DATABASE]
                  [--chunksize CHUNK_SIZE] [--path OUTPUT_PATH]
                  [--csvdialect CSV_DIALECT] [--csvencoding CSV_ENCODING]
-                 [--overwrite | --no-overwrite]
+                 [--overwrite | --no-overwrite] [--no-password]
                  table_name [table_name ...]
 
 generates CSV files from MySQL/MariaDB database tables
@@ -63,6 +63,12 @@ options:
                         if output files for the given tables already exist,
                         overwrite those files instead of skipping them
                         (default: False)
+  --no-password         indicates the database connection should be made
+                        without a password - this is distinct from an empty
+                        string password; if this argument and a password are
+                        given together the password argument will be ignored
+                        (default: False)
+
 ```
 
 #### Example Command-line Invocation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       DB_USER: "root"
       LOG_LEVEL: "DEBUG"
       OVERWRITE: 1
+      PASSWORD_REQUIRED: 1
     command:
       - time_zone
       - time_zone_transition

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       DB_USER: "root"
       LOG_LEVEL: "DEBUG"
       OVERWRITE: 1
-      PASSWORD_REQUIRED: 1
+      NO_PASSWORD: 0
     command:
       - time_zone
       - time_zone_transition

--- a/src/mysql2csv/__main__.py
+++ b/src/mysql2csv/__main__.py
@@ -189,6 +189,15 @@ def main() -> int:
             "can be specified)"
         ),
     )
+    argp.add_argument(
+        "--password_required",
+        action=argparse.BooleanOptionalAction,
+        default=parse_bool(os.environ.get("PASSWORD_REQUIRED", "1")),
+        help=(
+            "If database does not require a password for login, omit the argument "
+            "from the mariadb connection object to prevent connection failure"
+        ),
+    )
     args = argp.parse_args()
     logging.basicConfig(
         level=args.loglevel,
@@ -196,12 +205,20 @@ def main() -> int:
     )
 
     try:
-        with mariadb.connect(
-            user=args.user,
-            password=args.password,
-            host=args.host,
-            database=args.database,
-        ) as cnxn:
+        if args.password_required:
+            database_cnxn = mariadb.connect(
+                user=args.user,
+                password=args.password,
+                host=args.host,
+                database=args.database,
+            )
+        else:
+            database_cnxn = mariadb.connect(
+                user=args.user,
+                host=args.host,
+                database=args.database,
+            )
+        with database_cnxn as cnxn:
             dump_tables(
                 cnxn,
                 args.table_name,

--- a/src/mysql2csv/__main__.py
+++ b/src/mysql2csv/__main__.py
@@ -5,7 +5,7 @@ import csv
 import logging
 import os
 import sys
-from typing import Final, Sequence
+from typing import Dict, Final, Sequence
 
 import mariadb
 
@@ -89,6 +89,18 @@ def quoted_list(input: Sequence[str]) -> str:
 def parse_bool(argument: str) -> bool:
     """parses the given argument string and returns a boolean evaluation"""
     return argument.lower().strip() in ("1", "enable", "on", "true", "y", "yes")
+
+
+def log_config(args: argparse.Namespace) -> None:
+    """
+    given a parsed argument namespace, log it (while redacting the passwords
+    """
+    sensitive_items: Final = ("password",)
+
+    logging.info("--- Begin Config Report ---")
+    for k, v in vars(args).items():
+        logging.info('"%s": "%s"', k, v if k not in sensitive_items else "-REDACTED-")
+    logging.info("--- End Config Report ---")
 
 
 def main() -> int:
@@ -182,6 +194,17 @@ def main() -> int:
         ),
     )
     argp.add_argument(
+        "--no-password",
+        action="store_true",
+        default=parse_bool(os.environ.get("NO_PASSWORD", "0")),
+        help=(
+            "indicates the database connection should be made without a "
+            "password - this is distinct from an empty string password; if "
+            "this argument and a password are given together the password "
+            "argument will be ignored"
+        ),
+    )
+    argp.add_argument(
         "table_name",
         nargs="+",
         help=(
@@ -189,36 +212,26 @@ def main() -> int:
             "can be specified)"
         ),
     )
-    argp.add_argument(
-        "--password_required",
-        action=argparse.BooleanOptionalAction,
-        default=parse_bool(os.environ.get("PASSWORD_REQUIRED", "1")),
-        help=(
-            "If database does not require a password for login, omit the argument "
-            "from the mariadb connection object to prevent connection failure"
-        ),
-    )
     args = argp.parse_args()
     logging.basicConfig(
         level=args.loglevel,
         format=LOG_FORMAT,
     )
+    log_config(args)
+
+    connect_args: Dict[str, str] = {
+        "host": args.host,
+        "user": args.user,
+        "password": args.password,
+        "database": args.database,
+    }
+    if args.no_password and "password" in connect_args:
+        del connect_args["password"]
 
     try:
-        if args.password_required:
-            database_cnxn = mariadb.connect(
-                user=args.user,
-                password=args.password,
-                host=args.host,
-                database=args.database,
-            )
-        else:
-            database_cnxn = mariadb.connect(
-                user=args.user,
-                host=args.host,
-                database=args.database,
-            )
-        with database_cnxn as cnxn:
+        # see: https://mariadb.com/kb/en/mysql_real_connect/ and
+        # https://mariadb-corporation.github.io/mariadb-connector-python/module.html#mariadb.connect
+        with mariadb.connect(**connect_args) as cnxn:
             dump_tables(
                 cnxn,
                 args.table_name,


### PR DESCRIPTION
Execution failed on multiple MySQL databases without pw requirements for connection (both running OpenMRS). This PR adds an argument `PASSWORD_REQUIRED` which modifies the mariadb connector object arguments.