### PR TITLE
enable a --defer-exceptions arg / DEFER_EXCEPTIONS envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ usage: mysql2csv [-h] [--loglevel LOG_LEVEL] [--host DB_HOST] [--user DB_USER]
                  [--chunksize CHUNK_SIZE] [--path OUTPUT_PATH]
                  [--csvdialect CSV_DIALECT] [--csvencoding CSV_ENCODING]
                  [--overwrite | --no-overwrite] [--no-password]
+                 [--defer-exceptions | --no-defer-exceptions]
                  table_name [table_name ...]
 
 generates CSV files from MySQL/MariaDB database tables
@@ -68,6 +69,12 @@ options:
                         string password; if this argument and a password are
                         given together the password argument will be ignored
                         (default: False)
+  --defer-exceptions, --no-defer-exceptions
+                        indicates the program should attempt to keep running
+                        when a database error occurs; if the is not enabled
+                        the program will halt immediately when a database
+                        error occurs (default: False)
+
 
 ```
 
@@ -99,6 +106,7 @@ services:
       DB_USER: "root"
       LOG_LEVEL: "DEBUG"
       OVERWRITE: 1
+      DEFER_EXCEPTIONS: 1
     command:
       - time_zone
       - time_zone_transition

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,16 +15,17 @@ services:
       - db
     image: edence/mysql2csv
     build: .
-    environment:
-      CHUNK_SIZE: 100000
-      CSV_DIALECT: "excel"  # see also: unix ; https://docs.python.org/3/library/csv.html
-      DB_DATABASE: "mysql"
-      DB_HOST: "db"
-      DB_PASSWORD: "testing"
-      DB_USER: "root"
-      LOG_LEVEL: "DEBUG"
-      OVERWRITE: 1
-      NO_PASSWORD: 0
+    # environment:
+      # CHUNK_SIZE: 100000
+      # CSV_DIALECT: "excel"  # see also: unix ; https://docs.python.org/3/library/csv.html
+      # DB_DATABASE: "mysql"
+      # DB_HOST: "db"
+      # DB_PASSWORD: "testing"
+      # DB_USER: "root"
+      # LOG_LEVEL: "DEBUG"
+      # OVERWRITE: 1
+      # NO_PASSWORD: 0
+      # DEFER_EXCEPTIONS: 1
     command:
       - time_zone
       - time_zone_transition

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,17 +15,17 @@ services:
       - db
     image: edence/mysql2csv
     build: .
-    # environment:
-      # CHUNK_SIZE: 100000
-      # CSV_DIALECT: "excel"  # see also: unix ; https://docs.python.org/3/library/csv.html
-      # DB_DATABASE: "mysql"
-      # DB_HOST: "db"
-      # DB_PASSWORD: "testing"
-      # DB_USER: "root"
-      # LOG_LEVEL: "DEBUG"
-      # OVERWRITE: 1
-      # NO_PASSWORD: 0
-      # DEFER_EXCEPTIONS: 1
+    environment:
+      CHUNK_SIZE: 100000
+      CSV_DIALECT: "excel"  # see also: unix ; https://docs.python.org/3/library/csv.html
+      DB_DATABASE: "mysql"
+      DB_HOST: "db"
+      DB_PASSWORD: "testing"
+      DB_USER: "root"
+      LOG_LEVEL: "DEBUG"
+      OVERWRITE: 1
+      NO_PASSWORD: 0
+      DEFER_EXCEPTIONS: 1
     command:
       - time_zone
       - time_zone_transition


### PR DESCRIPTION
This option lets the program keep going if a database error occurs, such as when a table doesn't exist. The full list of exceptions is stored in memory then printed at the end of the run. Not enabled by default. 

Toggled via `--defer-exceptions` and `--no-defer-exceptions` cli-args and the `DEFER_EXCEPTIONS` boolean envvar.